### PR TITLE
Sanitize DUMPVOICES work to exist entirely at the bottom of FAudio.c

### DIFF
--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -2325,6 +2325,7 @@ uint32_t FAudioSourceVoice_SubmitSourceBuffer(
 	/* dumping current buffer, append into "data" section */
 	if (pBuffer->pAudioData != NULL && playLength > 0)
 	{
+		FAudio_DUMPVOICE_WriteBuffer(voice, pBuffer, pBufferWMA);
 	}
 #endif /* FAUDIO_DUMP_VOICES */
 


### PR DESCRIPTION
This should functionally be a no-op, but moves nearly 100% of the work to the bottom of the file. The Write section in particular is now its own function, so SubmitSourceBuffer itself is cleaner and the work in that Write function isn't quite so tabby as a result of being its own thing.